### PR TITLE
Use uniform code conventions

### DIFF
--- a/playground/Auth0.AspNetCore.Mvc.Playground/Program.cs
+++ b/playground/Auth0.AspNetCore.Mvc.Playground/Program.cs
@@ -1,11 +1,5 @@
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Auth0.AspNetCore.Mvc.Playground
 {

--- a/playground/Auth0.AspNetCore.Mvc.Playground/Startup.cs
+++ b/playground/Auth0.AspNetCore.Mvc.Playground/Startup.cs
@@ -5,7 +5,6 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 
 namespace Auth0.AspNetCore.Mvc.Playground
 {

--- a/playground/Auth0.AspNetCore.Mvc.Playground/Views/Shared/_Layout.cshtml
+++ b/playground/Auth0.AspNetCore.Mvc.Playground/Views/Shared/_Layout.cshtml
@@ -55,6 +55,6 @@
     <script src="~/lib/jquery/dist/jquery.min.js"></script>
     <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
     <script src="~/js/site.js" asp-append-version="true"></script>
-    @RenderSection("Scripts", required: false)
+    @await RenderSectionAsync("Scripts", required: false)
 </body>
 </html>

--- a/src/Auth0.AspNetCore.Mvc/Auth0WebAppAuthenticationBuilder.cs
+++ b/src/Auth0.AspNetCore.Mvc/Auth0WebAppAuthenticationBuilder.cs
@@ -8,18 +8,18 @@ namespace Auth0.AspNetCore.Mvc
     /// </summary>
     public class Auth0WebAppAuthenticationBuilder
     {
-        private readonly IServiceCollection services;
-        private readonly Auth0WebAppOptions options;
+        private readonly IServiceCollection _services;
+        private readonly Auth0WebAppOptions _options;
 
         /// <summary>
         /// Constructs an instance of <see cref="Auth0WebAppAuthenticationBuilder"/>
         /// </summary>
-        /// <param name="services">The original <see cref="https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.iservicecollection">IServiceCollection</see> instance</param>
+        /// <param name="services">The original <see href="https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.iservicecollection">IServiceCollection</see> instance</param>
         /// <param name="options">The <see cref="Auth0WebAppOptions"/> used when calling AddAuth0WebAppAuthentication.</param>
         public Auth0WebAppAuthenticationBuilder(IServiceCollection services, Auth0WebAppOptions options)
         {
-            this.services = services;
-            this.options = options;
+            _services = services;
+            _options = options;
         }
 
         /// <summary>
@@ -29,7 +29,7 @@ namespace Auth0.AspNetCore.Mvc
         /// <returns>An instance of <see cref="Auth0WebAppWithAccessTokenAuthenticationBuilder"/></returns>
         public Auth0WebAppWithAccessTokenAuthenticationBuilder WithAccessToken(Action<Auth0WebAppWithAccessTokenOptions> configureOptions)
         {
-            return new Auth0WebAppWithAccessTokenAuthenticationBuilder(this.services, configureOptions, this.options);
+            return new Auth0WebAppWithAccessTokenAuthenticationBuilder(_services, configureOptions, _options);
         }
     }
 }

--- a/src/Auth0.AspNetCore.Mvc/Auth0WebAppOptions.cs
+++ b/src/Auth0.AspNetCore.Mvc/Auth0WebAppOptions.cs
@@ -50,7 +50,7 @@ namespace Auth0.AspNetCore.Mvc
         /// <example>
         /// services.AddAuth0WebAppAuthentication(options =>
         /// {
-        ///     options.LoginParameters = new Dictionary<string, string>() { {"Test", "123" } };
+        ///     options.LoginParameters = new Dictionary{string, string}() { {"Test", "123" } };
         /// });
         /// </example>
         public IDictionary<string, string> LoginParameters { get; set; } = new Dictionary<string, string>();

--- a/src/Auth0.AspNetCore.Mvc/Auth0WebAppWithAccessTokenAuthenticationBuilder.cs
+++ b/src/Auth0.AspNetCore.Mvc/Auth0WebAppWithAccessTokenAuthenticationBuilder.cs
@@ -15,9 +15,9 @@ namespace Auth0.AspNetCore.Mvc
     /// </summary>
     public class Auth0WebAppWithAccessTokenAuthenticationBuilder
     {
-        private readonly IServiceCollection services;
-        private readonly Action<Auth0WebAppWithAccessTokenOptions> configureOptions;
-        private readonly Auth0WebAppOptions options;
+        private readonly IServiceCollection _services;
+        private readonly Action<Auth0WebAppWithAccessTokenOptions> _configureOptions;
+        private readonly Auth0WebAppOptions _options;
 
         private static readonly IList<string> CodeResponseTypes = new List<string>() {
             OpenIdConnectResponseType.Code,
@@ -27,14 +27,14 @@ namespace Auth0.AspNetCore.Mvc
         /// <summary>
         /// Constructs an instance of <see cref="Auth0WebAppWithAccessTokenAuthenticationBuilder"/>
         /// </summary>
-        /// <param name="services">The original <see cref="https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.iservicecollection">IServiceCollection</see> instance</param>
+        /// <param name="services">The original <see href="https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.iservicecollection">IServiceCollection</see> instance</param>
         /// <param name="configureOptions">A delegate used to configure the <see cref="Auth0WebAppWithAccessTokenOptions"/></param>
         /// <param name="options">The <see cref="Auth0WebAppOptions"/> used when calling AddAuth0WebAppAuthentication.</param>
         public Auth0WebAppWithAccessTokenAuthenticationBuilder(IServiceCollection services, Action<Auth0WebAppWithAccessTokenOptions> configureOptions, Auth0WebAppOptions options)
         {
-            this.services = services;
-            this.configureOptions = configureOptions;
-            this.options = options;
+            _services = services;
+            _configureOptions = configureOptions;
+            _options = options;
 
             EnableWithAccessToken();
         }
@@ -43,12 +43,12 @@ namespace Auth0.AspNetCore.Mvc
         {
             var auth0WithAccessTokensOptions = new Auth0WebAppWithAccessTokenOptions();
 
-            configureOptions(auth0WithAccessTokensOptions);
+            _configureOptions(auth0WithAccessTokensOptions);
             
-            ValidateOptions(options);
+            ValidateOptions(_options);
 
-            this.services.AddSingleton(auth0WithAccessTokensOptions);
-            this.services.AddOptions<OpenIdConnectOptions>(Auth0Constants.AuthenticationScheme)
+            _services.AddSingleton(auth0WithAccessTokensOptions);
+            _services.AddOptions<OpenIdConnectOptions>(Auth0Constants.AuthenticationScheme)
                 .Configure<IServiceProvider>((options, serviceProvider) =>
                 {
                     options.ResponseType = OpenIdConnectResponseType.Code;
@@ -66,7 +66,7 @@ namespace Auth0.AspNetCore.Mvc
                     options.Events.OnRedirectToIdentityProvider = Utils.ProxyEvent(CreateOnRedirectToIdentityProvider(auth0WithAccessTokensOptions), options.Events.OnRedirectToIdentityProvider);
                 });
 
-            this.services.AddOptions<CookieAuthenticationOptions>(CookieAuthenticationDefaults.AuthenticationScheme)
+            _services.AddOptions<CookieAuthenticationOptions>(CookieAuthenticationDefaults.AuthenticationScheme)
                 .Configure<IServiceProvider>((options, serviceProvider) =>
                 {
                     options.Events.OnValidatePrincipal = Utils.ProxyEvent(CreateOnValidatePrincipal(auth0WithAccessTokensOptions), options.Events.OnValidatePrincipal);
@@ -97,13 +97,11 @@ namespace Auth0.AspNetCore.Mvc
             {
                 var options = context.HttpContext.RequestServices.GetRequiredService<Auth0WebAppOptions>();
 
-                string accessToken;
-                if (context.Properties.Items.TryGetValue(".Token.access_token", out accessToken))
+                if (context.Properties.Items.TryGetValue(".Token.access_token", out _))
                 {
                     if (auth0Options.UseRefreshTokens)
                     {
-                        string refreshToken;
-                        if (context.Properties.Items.TryGetValue(".Token.refresh_token", out refreshToken))
+                        if (context.Properties.Items.TryGetValue(".Token.refresh_token", out var refreshToken))
                         {
                             var now = DateTimeOffset.Now;
                             var expiresAt = DateTimeOffset.Parse(context.Properties.Items[".Token.expires_at"]);
@@ -144,7 +142,7 @@ namespace Auth0.AspNetCore.Mvc
                 {
                     if (CodeResponseTypes.Contains(options.ResponseType))
                     {
-                        if (auth0Options.Events != null && auth0Options.Events.OnMissingAccessToken != null)
+                        if (auth0Options.Events?.OnMissingAccessToken != null)
                         {
                             await auth0Options.Events.OnMissingAccessToken(context.HttpContext);
                         }

--- a/src/Auth0.AspNetCore.Mvc/AuthenticationBuilderExtensions.cs
+++ b/src/Auth0.AspNetCore.Mvc/AuthenticationBuilderExtensions.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
@@ -9,9 +8,6 @@ using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
-using System.Threading.Tasks;
 
 namespace Auth0.AspNetCore.Mvc
 {
@@ -20,7 +16,7 @@ namespace Auth0.AspNetCore.Mvc
     /// </summary>
     public static class AuthenticationBuilderExtensions
     {
-        private static IList<string> codeResponseTypes = new List<string>() {
+        private static readonly IList<string> CodeResponseTypes = new List<string>() {
             OpenIdConnectResponseType.Code,
             OpenIdConnectResponseType.CodeIdToken
         };
@@ -51,7 +47,7 @@ namespace Auth0.AspNetCore.Mvc
         /// <summary>
         /// Configure Open ID Connect based on the provided <see cref="Auth0WebAppOptions"/>.
         /// </summary>
-        /// <param name="oidcOptions">A reference to the <see href="https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.authentication.openidconnect.openidconnectoptions">OpenIdConnectOptions</see> that needs to be configured./param>
+        /// <param name="oidcOptions">A reference to the <see href="https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.authentication.openidconnect.openidconnectoptions">OpenIdConnectOptions</see> that needs to be configured.</param>
         /// <param name="auth0Options">The provided <see cref="Auth0WebAppOptions"/>.</param>
         private static void ConfigureOpenIdConnect(OpenIdConnectOptions oidcOptions, Auth0WebAppOptions auth0Options)
         {
@@ -87,7 +83,7 @@ namespace Auth0.AspNetCore.Mvc
 
         private static void ValidateOptions(Auth0WebAppOptions auth0Options)
         {
-            if (codeResponseTypes.Contains(auth0Options.ResponseType) && string.IsNullOrWhiteSpace(auth0Options.ClientSecret))
+            if (CodeResponseTypes.Contains(auth0Options.ResponseType) && string.IsNullOrWhiteSpace(auth0Options.ClientSecret))
             {
                 throw new ArgumentNullException(nameof(auth0Options.ClientSecret), "Client Secret can not be null when using `code` or `code id_token` as the response_type.");
             }

--- a/src/Auth0.AspNetCore.Mvc/OpenIdConnectEventsFactory.cs
+++ b/src/Auth0.AspNetCore.Mvc/OpenIdConnectEventsFactory.cs
@@ -31,7 +31,7 @@ namespace Auth0.AspNetCore.Mvc
 
         private static Func<T, Task> ProxyEvent<T>(Func<T, Task> originalHandler, Func<T, Task> newHandler = null)
         {
-            return async (T context) =>
+            return async (context) =>
             {
                 if (newHandler != null)
                 {
@@ -134,9 +134,9 @@ namespace Auth0.AspNetCore.Mvc
             // Extra Parameters
             if (auth0Options.LoginParameters != null)
             {
-                foreach (var extraParam in auth0Options.LoginParameters)
+                foreach (var (key, value) in auth0Options.LoginParameters)
                 {
-                    parameters[extraParam.Key] = extraParam.Value;
+                    parameters[key] = value;
                 }
             }
 

--- a/src/Auth0.AspNetCore.Mvc/ServiceCollectionExtensions.cs
+++ b/src/Auth0.AspNetCore.Mvc/ServiceCollectionExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Authentication.Cookies;
+﻿using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 
@@ -13,7 +12,7 @@ namespace Auth0.AspNetCore.Mvc
         /// <summary>
         /// Add Auth0 configuration using Open ID Connect
         /// </summary>
-        /// <param name="services">The original <see cref="https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.iservicecollection">IServiceCollection</see> instance</param>
+        /// <param name="services">The original <see href="https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.iservicecollection">IServiceCollection</see> instance</param>
         /// <param name="configureOptions">A delegate used to configure the <see cref="Auth0WebAppOptions"/></param>
         /// <returns>The <see cref="Auth0WebAppAuthenticationBuilder"/> instance that has been created.</returns>
         public static Auth0WebAppAuthenticationBuilder AddAuth0WebAppAuthentication(this IServiceCollection services, Action<Auth0WebAppOptions> configureOptions)

--- a/src/Auth0.AspNetCore.Mvc/TokenClient.cs
+++ b/src/Auth0.AspNetCore.Mvc/TokenClient.cs
@@ -9,9 +9,9 @@ namespace Auth0.AspNetCore.Mvc
 {
     internal class TokenClient : IDisposable
     {
-        private readonly HttpClient httpClient;
-        private readonly bool isHttpClientOwner;
-        private readonly JsonSerializerSettings jsonSerializerSettings = new JsonSerializerSettings
+        private readonly HttpClient _httpClient;
+        private readonly bool _isHttpClientOwner;
+        private readonly JsonSerializerSettings _jsonSerializerSettings = new JsonSerializerSettings
         {
             NullValueHandling = NullValueHandling.Ignore,
             DateParseHandling = DateParseHandling.DateTime
@@ -19,15 +19,15 @@ namespace Auth0.AspNetCore.Mvc
 
         public TokenClient(HttpClient httpClient = null)
         {
-            this.isHttpClientOwner = httpClient == null;
-            this.httpClient = httpClient ?? new HttpClient();
+            _isHttpClientOwner = httpClient == null;
+            _httpClient = httpClient ?? new HttpClient();
         }
 
         public void Dispose()
         {
-            if (this.isHttpClientOwner)
+            if (_isHttpClientOwner)
             {
-                this.httpClient.Dispose();
+                _httpClient.Dispose();
             }
         }
 
@@ -44,7 +44,7 @@ namespace Auth0.AspNetCore.Mvc
 
             using (var request = new HttpRequestMessage(HttpMethod.Post, $"https://{options.Domain}/oauth/token") { Content = requestContent })
             {
-                using (var response = await httpClient.SendAsync(request).ConfigureAwait(false))
+                using (var response = await _httpClient.SendAsync(request).ConfigureAwait(false))
                 {
                     if (!response.IsSuccessStatusCode)
                     {
@@ -53,7 +53,7 @@ namespace Auth0.AspNetCore.Mvc
 
                     var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
-                    return JsonConvert.DeserializeObject<AccessTokenResponse>(responseContent, jsonSerializerSettings);
+                    return JsonConvert.DeserializeObject<AccessTokenResponse>(responseContent, _jsonSerializerSettings);
                 }
             }
         }

--- a/src/Auth0.AspNetCore.Mvc/Utils.cs
+++ b/src/Auth0.AspNetCore.Mvc/Utils.cs
@@ -27,7 +27,7 @@ namespace Auth0.AspNetCore.Mvc
         public static string CreateAgentString()
         {
             var sdkVersion = typeof(AuthenticationBuilderExtensions).GetTypeInfo().Assembly.GetName().Version;
-            var agentJson = $"{{\"name\":\"aspnetcore-mvc\",\"version\":\"{sdkVersion.Major}.{sdkVersion.Minor}.{sdkVersion.Revision}\"}}";
+            var agentJson = $"{{\"name\":\"aspnetcore-mvc\",\"version\":\"{sdkVersion?.Major}.{sdkVersion?.Minor}.{sdkVersion?.Revision}\"}}";
             return Convert.ToBase64String(Encoding.UTF8.GetBytes(agentJson));
         }
 

--- a/tests/Auth0.AspNetCore.Mvc.IntegrationTests/Auth0MiddlewareTests.cs
+++ b/tests/Auth0.AspNetCore.Mvc.IntegrationTests/Auth0MiddlewareTests.cs
@@ -12,6 +12,10 @@ using System.Net.Http;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.Extensions.DependencyInjection;
 using System.Net;
+using Auth0.AspNetCore.Mvc.IntegrationTests.Builders;
+using Auth0.AspNetCore.Mvc.IntegrationTests.Extensions;
+using Auth0.AspNetCore.Mvc.IntegrationTests.Infrastructure;
+using Auth0.AspNetCore.Mvc.IntegrationTests.Utils;
 
 namespace Auth0.AspNetCore.Mvc.IntegrationTests
 {
@@ -33,7 +37,7 @@ namespace Auth0.AspNetCore.Mvc.IntegrationTests
                 using (var client = server.CreateClient())
                 {
                     var response = (await client.SendAsync($"{TestServerBuilder.Host}/{TestServerBuilder.Protected}"));
-                    response.StatusCode.Should().Be(System.Net.HttpStatusCode.Found);
+                    response.StatusCode.Should().Be(HttpStatusCode.Found);
                     response.Headers.Location.AbsoluteUri.Should().Contain(TestServerBuilder.Login);
                 }
             }
@@ -47,7 +51,7 @@ namespace Auth0.AspNetCore.Mvc.IntegrationTests
                 using (var client = server.CreateClient())
                 {
                     var response = (await client.SendAsync($"{TestServerBuilder.Host}/{TestServerBuilder.Protected}"));
-                    response.StatusCode.Should().Be(System.Net.HttpStatusCode.Found);
+                    response.StatusCode.Should().Be(HttpStatusCode.Found);
                     response.Headers.Location.AbsoluteUri.Should().Contain(TestServerBuilder.Login);
                 }
             }
@@ -61,7 +65,7 @@ namespace Auth0.AspNetCore.Mvc.IntegrationTests
                 using (var client = server.CreateClient())
                 {
                     var response = await client.GetAsync($"{TestServerBuilder.Host}/{TestServerBuilder.Login}");
-                    response.StatusCode.Should().Be(System.Net.HttpStatusCode.Redirect);
+                    response.StatusCode.Should().Be(HttpStatusCode.Redirect);
                     response.Headers.Location.AbsoluteUri.Should().Contain(Configuration["Auth0:Domain"]);
                 }
             }
@@ -75,7 +79,7 @@ namespace Auth0.AspNetCore.Mvc.IntegrationTests
                 using (var client = server.CreateClient())
                 {
                     var response = await client.GetAsync($"{TestServerBuilder.Host}/{TestServerBuilder.Login}");
-                    response.StatusCode.Should().Be(System.Net.HttpStatusCode.Redirect);
+                    response.StatusCode.Should().Be(HttpStatusCode.Redirect);
 
                     var redirectUri = response.Headers.Location;
 
@@ -93,7 +97,7 @@ namespace Auth0.AspNetCore.Mvc.IntegrationTests
                 using (var client = server.CreateClient())
                 {
                     var response = await client.GetAsync($"{TestServerBuilder.Host}/{TestServerBuilder.Login}");
-                    response.StatusCode.Should().Be(System.Net.HttpStatusCode.Redirect);
+                    response.StatusCode.Should().Be(HttpStatusCode.Redirect);
 
                     var redirectUri = response.Headers.Location;
 
@@ -120,7 +124,7 @@ namespace Auth0.AspNetCore.Mvc.IntegrationTests
                 using (var client = server.CreateClient())
                 {
                     var response = await client.GetAsync($"{TestServerBuilder.Host}/{TestServerBuilder.Login}");
-                    response.StatusCode.Should().Be(System.Net.HttpStatusCode.Redirect);
+                    response.StatusCode.Should().Be(HttpStatusCode.Redirect);
 
                     var redirectUri = response.Headers.Location;
 
@@ -140,7 +144,7 @@ namespace Auth0.AspNetCore.Mvc.IntegrationTests
                 using (var client = server.CreateClient())
                 {
                     var response = await client.GetAsync($"{TestServerBuilder.Host}/{TestServerBuilder.Login}?scope={scope}");
-                    response.StatusCode.Should().Be(System.Net.HttpStatusCode.Redirect);
+                    response.StatusCode.Should().Be(HttpStatusCode.Redirect);
 
                     var redirectUri = response.Headers.Location;
 
@@ -160,7 +164,7 @@ namespace Auth0.AspNetCore.Mvc.IntegrationTests
                 using (var client = server.CreateClient())
                 {
                     var response = await client.GetAsync($"{TestServerBuilder.Host}/{TestServerBuilder.Login}");
-                    response.StatusCode.Should().Be(System.Net.HttpStatusCode.Redirect);
+                    response.StatusCode.Should().Be(HttpStatusCode.Redirect);
 
                     var redirectUri = response.Headers.Location;
 
@@ -184,7 +188,7 @@ namespace Auth0.AspNetCore.Mvc.IntegrationTests
                 using (var client = server.CreateClient())
                 {
                     var response = await client.GetAsync($"{TestServerBuilder.Host}/{TestServerBuilder.Login}");
-                    response.StatusCode.Should().Be(System.Net.HttpStatusCode.Redirect);
+                    response.StatusCode.Should().Be(HttpStatusCode.Redirect);
 
                     var redirectUri = response.Headers.Location;
 
@@ -204,7 +208,7 @@ namespace Auth0.AspNetCore.Mvc.IntegrationTests
                 using (var client = server.CreateClient())
                 {
                     var response = await client.GetAsync($"{TestServerBuilder.Host}/{TestServerBuilder.Login}?scope={scope}");
-                    response.StatusCode.Should().Be(System.Net.HttpStatusCode.Redirect);
+                    response.StatusCode.Should().Be(HttpStatusCode.Redirect);
 
                     var redirectUri = response.Headers.Location;
 
@@ -226,7 +230,7 @@ namespace Auth0.AspNetCore.Mvc.IntegrationTests
                 using (var client = server.CreateClient())
                 {
                     var response = await client.GetAsync($"{TestServerBuilder.Host}/{TestServerBuilder.Login}");
-                    response.StatusCode.Should().Be(System.Net.HttpStatusCode.Redirect);
+                    response.StatusCode.Should().Be(HttpStatusCode.Redirect);
 
                     var redirectUri = response.Headers.Location;
 
@@ -247,7 +251,7 @@ namespace Auth0.AspNetCore.Mvc.IntegrationTests
                     client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Test");
 
                     var response = await client.GetAsync($"{TestServerBuilder.Host}/{TestServerBuilder.Logout}");
-                    response.StatusCode.Should().Be(System.Net.HttpStatusCode.Redirect);
+                    response.StatusCode.Should().Be(HttpStatusCode.Redirect);
 
                     var redirectUri = response.Headers.Location;
 
@@ -268,7 +272,7 @@ namespace Auth0.AspNetCore.Mvc.IntegrationTests
 
                     var response = await client.GetAsync($"{TestServerBuilder.Host}/{TestServerBuilder.Logout}?extraParameters[0].Key=Test&extraParameters[0].Value=123&extraParameters[1].Key=federated&extraParameters[1].Value=");
 
-                    response.StatusCode.Should().Be(System.Net.HttpStatusCode.Redirect);
+                    response.StatusCode.Should().Be(HttpStatusCode.Redirect);
 
                     var redirectUri = response.Headers.Location;
                     var queryParameters = UriUtils.GetQueryParams(redirectUri);
@@ -308,7 +312,8 @@ namespace Auth0.AspNetCore.Mvc.IntegrationTests
             {
                 using (var client = server.CreateClient())
                 {
-                    var response = await client.GetAsync(string.Format("{0}?extraParameters[0].Key=Test&extraParameters[0].Value=123", $"{TestServerBuilder.Host}/{TestServerBuilder.Login}"));
+                    var response = await client.GetAsync(
+                        $"{TestServerBuilder.Host}/{TestServerBuilder.Login}?extraParameters[0].Key=Test&extraParameters[0].Value=123");
                     var redirectUri = response.Headers.Location;
                     var queryParameters = UriUtils.GetQueryParams(redirectUri);
 
@@ -327,7 +332,8 @@ namespace Auth0.AspNetCore.Mvc.IntegrationTests
             {
                 using (var client = server.CreateClient())
                 {
-                    var response = await client.GetAsync(string.Format("{0}?extraParameters[0].Key=Test&extraParameters[0].Value=456", $"{TestServerBuilder.Host}/{TestServerBuilder.Login}"));
+                    var response = await client.GetAsync(
+                        $"{TestServerBuilder.Host}/{TestServerBuilder.Login}?extraParameters[0].Key=Test&extraParameters[0].Value=456");
                     var redirectUri = response.Headers.Location;
                     var queryParameters = UriUtils.GetQueryParams(redirectUri);
 
@@ -384,8 +390,9 @@ namespace Auth0.AspNetCore.Mvc.IntegrationTests
             {
                 using (var client = server.CreateClient())
                 {
-                    var response = await client.GetAsync(string.Format("{0}?organization={1}", $"{TestServerBuilder.Host}/{TestServerBuilder.Login}", "123"));
-                    response.StatusCode.Should().Be(System.Net.HttpStatusCode.Redirect);
+                    var response = await client.GetAsync(
+                        $"{TestServerBuilder.Host}/{TestServerBuilder.Login}?organization={"123"}");
+                    response.StatusCode.Should().Be(HttpStatusCode.Redirect);
 
                     var redirectUri = response.Headers.Location;
 
@@ -406,8 +413,9 @@ namespace Auth0.AspNetCore.Mvc.IntegrationTests
             {
                 using (var client = server.CreateClient())
                 {
-                    var response = await client.GetAsync(string.Format("{0}?organization={1}", $"{TestServerBuilder.Host}/{TestServerBuilder.Login}", "456"));
-                    response.StatusCode.Should().Be(System.Net.HttpStatusCode.Redirect);
+                    var response = await client.GetAsync(
+                        $"{$"{TestServerBuilder.Host}/{TestServerBuilder.Login}"}?organization={"456"}");
+                    response.StatusCode.Should().Be(HttpStatusCode.Redirect);
 
                     var redirectUri = response.Headers.Location;
 
@@ -425,8 +433,9 @@ namespace Auth0.AspNetCore.Mvc.IntegrationTests
             {
                 using (var client = server.CreateClient())
                 {
-                    var response = await client.GetAsync(string.Format("{0}?invitation={1}", $"{TestServerBuilder.Host}/{TestServerBuilder.Login}", "123"));
-                    response.StatusCode.Should().Be(System.Net.HttpStatusCode.Redirect);
+                    var response = await client.GetAsync(
+                        $"{$"{TestServerBuilder.Host}/{TestServerBuilder.Login}"}?invitation={"123"}");
+                    response.StatusCode.Should().Be(HttpStatusCode.Redirect);
 
                     var redirectUri = response.Headers.Location;
 
@@ -492,7 +501,8 @@ namespace Auth0.AspNetCore.Mvc.IntegrationTests
             {
                 using (var client = server.CreateClient())
                 {
-                    var response = await client.GetAsync(string.Format("{0}?audience={1}", $"{TestServerBuilder.Host}/{TestServerBuilder.Login}", "http://local.auth0"));
+                    var response = await client.GetAsync(
+                        $"{$"{TestServerBuilder.Host}/{TestServerBuilder.Login}"}?audience={"http://local.auth0"}");
                     var redirectUri = response.Headers.Location;
                     var queryParameters = UriUtils.GetQueryParams(redirectUri);
 
@@ -515,7 +525,8 @@ namespace Auth0.AspNetCore.Mvc.IntegrationTests
             {
                 using (var client = server.CreateClient())
                 {
-                    var response = await client.GetAsync(string.Format("{0}?audience={1}", $"{TestServerBuilder.Host}/{TestServerBuilder.Login}", "http://remote.auth0"));
+                    var response = await client.GetAsync(
+                        $"{$"{TestServerBuilder.Host}/{TestServerBuilder.Login}"}?audience={"http://remote.auth0"}");
                     var redirectUri = response.Headers.Location;
                     var queryParameters = UriUtils.GetQueryParams(redirectUri);
 
@@ -919,7 +930,6 @@ namespace Auth0.AspNetCore.Mvc.IntegrationTests
         [Fact]
         public async void Should_Call_On_Access_Token_Missing()
         {
-            var nonce = "";
             var configuration = TestConfiguration.GetConfiguration();
             var domain = configuration["Auth0:Domain"];
             var clientId = configuration["Auth0:ClientId"];
@@ -938,9 +948,10 @@ namespace Auth0.AspNetCore.Mvc.IntegrationTests
             {
                 opts.Events = new Auth0WebAppWithAccessTokenEvents
                 {
-                    OnMissingAccessToken = async (context) =>
+                    OnMissingAccessToken = (context) =>
                     {
                         context.Response.Redirect("http://missing.at/");
+                        return Task.CompletedTask;
                     }
                 };
             }))
@@ -956,16 +967,20 @@ namespace Auth0.AspNetCore.Mvc.IntegrationTests
                     // Keep track of the nonce as we need to:
                     // - Send it to the `/oauth/token` endpoint
                     // - Include it in the generated ID Token
-                    nonce = queryParameters["nonce"];
+                    var nonce = queryParameters["nonce"];
 
                     // Keep track of the state as we need to:
                     // - Send it to the `/oauth/token` endpoint
                     var state = queryParameters["state"];
 
-                    var nvc = new List<KeyValuePair<string, string>>();
-                    nvc.Add(new KeyValuePair<string, string>("state", state));
-                    nvc.Add(new KeyValuePair<string, string>("nonce", nonce));
-                    nvc.Add(new KeyValuePair<string, string>("id_token", JwtUtils.GenerateToken(1, $"https://{domain}/", clientId, null, nonce, DateTime.Now.AddSeconds(20))));
+                    var nvc = new List<KeyValuePair<string, string>>
+                    {
+                        new KeyValuePair<string, string>("state", state),
+                        new KeyValuePair<string, string>("nonce", nonce),
+                        new KeyValuePair<string, string>("id_token",
+                            JwtUtils.GenerateToken(1, $"https://{domain}/", clientId, null, nonce,
+                                DateTime.Now.AddSeconds(20)))
+                    };
 
                     var message = new HttpRequestMessage(HttpMethod.Post, $"{TestServerBuilder.Host}/{TestServerBuilder.Callback}") { Content = new FormUrlEncodedContent(nvc) };
 
@@ -1006,9 +1021,10 @@ namespace Auth0.AspNetCore.Mvc.IntegrationTests
                 opts.Audience = "123";
                 opts.Events = new Auth0WebAppWithAccessTokenEvents
                 {
-                    OnMissingRefreshToken = async (context) =>
+                    OnMissingRefreshToken = (context) =>
                     {
                         context.Response.Redirect("http://missing.rt/");
+                        return Task.CompletedTask;
                     }
                 };
             }))

--- a/tests/Auth0.AspNetCore.Mvc.IntegrationTests/Builders/OidcMockBuilder.cs
+++ b/tests/Auth0.AspNetCore.Mvc.IntegrationTests/Builders/OidcMockBuilder.cs
@@ -1,21 +1,22 @@
-﻿using Moq;
-using Moq.Protected;
-using System;
+﻿using System;
 using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Auth0.AspNetCore.Mvc.IntegrationTests.Extensions;
+using Moq;
+using Moq.Protected;
 
-namespace Auth0.AspNetCore.Mvc.IntegrationTests
+namespace Auth0.AspNetCore.Mvc.IntegrationTests.Builders
 {
     /// <summary>
-    /// Builder used to set up a Mock<HttpMessageHandler> that handles the Oidc and OAuth requests.
+    /// Builder used to set up a Mock{HttpMessageHandler} that handles the Oidc and OAuth requests.
     /// </summary>
     public class OidcMockBuilder
     {
-        private Mock<HttpMessageHandler> _mockHandler = new Mock<HttpMessageHandler>();
+        private readonly Mock<HttpMessageHandler> _mockHandler = new Mock<HttpMessageHandler>();
 
         /// <summary>
         /// Mock the `.well-known/openid-configuration` request.
@@ -68,13 +69,10 @@ namespace Auth0.AspNetCore.Mvc.IntegrationTests
                  ItExpr.Is<HttpRequestMessage>(me => me.IsTokenEndPoint() && (matcher == null || matcher(me))),
                  ItExpr.IsAny<CancellationToken>()
               )
-              .ReturnsAsync(() =>
+              .ReturnsAsync(() => new HttpResponseMessage()
               {
-                  return new HttpResponseMessage()
-                  {
-                      StatusCode = statusCode,
-                      Content = new StringContent(BuildTokenRespone(idTokenFunc(), expiresIn, includeAccessToken, includeRefreshToken)),
-                  };
+                  StatusCode = statusCode,
+                  Content = new StringContent(BuildTokenRespone(idTokenFunc(), expiresIn, includeAccessToken, includeRefreshToken)),
               })
               .Verifiable();
 

--- a/tests/Auth0.AspNetCore.Mvc.IntegrationTests/Extensions/HttpClientExtensions.cs
+++ b/tests/Auth0.AspNetCore.Mvc.IntegrationTests/Extensions/HttpClientExtensions.cs
@@ -2,7 +2,7 @@
 using System.Net.Http;
 using System.Threading.Tasks;
 
-namespace Auth0.AspNetCore.Mvc.IntegrationTests
+namespace Auth0.AspNetCore.Mvc.IntegrationTests.Extensions
 {
     /// <summary>
     /// HttpClient Extensions to support a URL as a string as well as cookie headers.

--- a/tests/Auth0.AspNetCore.Mvc.IntegrationTests/Extensions/HttpRequestMessageExtensions.cs
+++ b/tests/Auth0.AspNetCore.Mvc.IntegrationTests/Extensions/HttpRequestMessageExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using System.Net.Http;
 
-namespace Auth0.AspNetCore.Mvc.IntegrationTests
+namespace Auth0.AspNetCore.Mvc.IntegrationTests.Extensions
 {
     /// <summary>
     /// HttpRequestMessage Extensions to be able to easily filter certain requests.

--- a/tests/Auth0.AspNetCore.Mvc.IntegrationTests/Infrastructure/TestAuthHandler.cs
+++ b/tests/Auth0.AspNetCore.Mvc.IntegrationTests/Infrastructure/TestAuthHandler.cs
@@ -1,12 +1,12 @@
-﻿using Microsoft.AspNetCore.Authentication;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using System.Security.Claims;
+﻿using System.Security.Claims;
 using System.Security.Principal;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
-namespace Auth0.AspNetCore.Mvc.IntegrationTests
+namespace Auth0.AspNetCore.Mvc.IntegrationTests.Infrastructure
 {
     /// <summary>
     ///  AuthenticationHandler used to Mock the Authentication in Integration Tests that an authenticated user to be available

--- a/tests/Auth0.AspNetCore.Mvc.IntegrationTests/Infrastructure/TestConfiguration.cs
+++ b/tests/Auth0.AspNetCore.Mvc.IntegrationTests/Infrastructure/TestConfiguration.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.Extensions.Configuration;
 
-namespace Auth0.AspNetCore.Mvc.IntegrationTests
+namespace Auth0.AspNetCore.Mvc.IntegrationTests.Infrastructure
 {
     /// <summary>
     /// Helper class to load the Configuration from the appsettings.json file.
@@ -11,14 +11,9 @@ namespace Auth0.AspNetCore.Mvc.IntegrationTests
 
         public static IConfiguration GetConfiguration()
         {
-            if (_configuration == null)
-            {
-                _configuration = new ConfigurationBuilder()
+            return _configuration ??= new ConfigurationBuilder()
                 .AddJsonFile("appsettings.json")
                 .Build();
-            }
-
-            return _configuration;
         }
     }
 }

--- a/tests/Auth0.AspNetCore.Mvc.IntegrationTests/Infrastructure/TestServerBuilder.cs
+++ b/tests/Auth0.AspNetCore.Mvc.IntegrationTests/Infrastructure/TestServerBuilder.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Text.Json;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Builder;
@@ -10,7 +9,7 @@ using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-namespace Auth0.AspNetCore.Mvc.IntegrationTests
+namespace Auth0.AspNetCore.Mvc.IntegrationTests.Infrastructure
 {
     /// <summary>
     /// Helper class to create an instance of the TestServer to use for Integration Tests.

--- a/tests/Auth0.AspNetCore.Mvc.IntegrationTests/TokenValidationTests.cs
+++ b/tests/Auth0.AspNetCore.Mvc.IntegrationTests/TokenValidationTests.cs
@@ -7,6 +7,10 @@ using Xunit;
 using System.Net.Http;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
+using Auth0.AspNetCore.Mvc.IntegrationTests.Builders;
+using Auth0.AspNetCore.Mvc.IntegrationTests.Extensions;
+using Auth0.AspNetCore.Mvc.IntegrationTests.Infrastructure;
+using Auth0.AspNetCore.Mvc.IntegrationTests.Utils;
 using Microsoft.IdentityModel.Tokens;
 
 namespace Auth0.AspNetCore.Mvc.IntegrationTests
@@ -596,7 +600,7 @@ namespace Auth0.AspNetCore.Mvc.IntegrationTests
 
         }
 
-        private string GenerateToken(int userId, string issuer, string audience, string nonce, string subject, string org_id = null, bool expired = false, string extraAudience = null, string azp = null, DateTime? authTime = null)
+        private string GenerateToken(int userId, string issuer, string audience, string nonce, string subject, string orgId = null, bool expired = false, string extraAudience = null, string azp = null, DateTime? authTime = null)
         {
             var tokenHandler = new JwtSecurityTokenHandler();
             var claims = new List<Claim>
@@ -614,9 +618,9 @@ namespace Auth0.AspNetCore.Mvc.IntegrationTests
                 claims.Add(new Claim(JwtRegisteredClaimNames.Aud, extraAudience));
             }
 
-            if (!string.IsNullOrWhiteSpace(org_id))
+            if (!string.IsNullOrWhiteSpace(orgId))
             {
-                claims.Add(new Claim("org_id", org_id));
+                claims.Add(new Claim("org_id", orgId));
             }
 
             if (!string.IsNullOrWhiteSpace(nonce))

--- a/tests/Auth0.AspNetCore.Mvc.IntegrationTests/Utils/JwtUtils.cs
+++ b/tests/Auth0.AspNetCore.Mvc.IntegrationTests/Utils/JwtUtils.cs
@@ -1,13 +1,12 @@
-﻿using Microsoft.IdentityModel.Tokens;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.IO;
 using System.Security.Claims;
-using System.Security.Cryptography;
 using System.Threading.Tasks;
+using Microsoft.IdentityModel.Tokens;
 
-namespace Auth0.AspNetCore.Mvc.IntegrationTests
+namespace Auth0.AspNetCore.Mvc.IntegrationTests.Utils
 {
     /// <summary>
     /// Utils class to generate a JWT token for testing purposes.
@@ -20,10 +19,10 @@ namespace Auth0.AspNetCore.Mvc.IntegrationTests
         /// <param name="userId">The user's ID, used as Name and sub claim.</param>
         /// <param name="issuer">The token's Issuer.</param>
         /// <param name="audience">The token's Audience</param>
-        /// <param name="org_id">The (optional) org_id claim to be used.</param>
+        /// <param name="orgId">The (optional) org_id claim to be used.</param>
         /// <param name="nonce">The (optional) nonce to be used.</param>
         /// <returns>The generated JWT token.</returns>
-        public static string GenerateToken(int userId, string issuer, string audience, string org_id = null, string nonce = null, DateTime? expires = null)
+        public static string GenerateToken(int userId, string issuer, string audience, string orgId = null, string nonce = null, DateTime? expires = null)
         {
             var tokenHandler = new JwtSecurityTokenHandler();
             var claims = new List<Claim>
@@ -32,9 +31,9 @@ namespace Auth0.AspNetCore.Mvc.IntegrationTests
                 new Claim(JwtRegisteredClaimNames.Sub, userId.ToString()),
             };
 
-            if (!string.IsNullOrWhiteSpace(org_id))
+            if (!string.IsNullOrWhiteSpace(orgId))
             {
-                claims.Add(new Claim("org_id", org_id));
+                claims.Add(new Claim("org_id", orgId));
             }
 
             if (!string.IsNullOrWhiteSpace(nonce))
@@ -47,7 +46,7 @@ namespace Auth0.AspNetCore.Mvc.IntegrationTests
             var tokenDescriptor = new SecurityTokenDescriptor
             {
                 Subject = new ClaimsIdentity(claims),
-                Expires = expires != null ? expires : DateTime.UtcNow.AddDays(7),
+                Expires = expires ?? DateTime.UtcNow.AddDays(7),
                 Issuer = issuer,
                 Audience = audience,
                 SigningCredentials = new SigningCredentials(keys.Keys[0], SecurityAlgorithms.RsaSha256)

--- a/tests/Auth0.AspNetCore.Mvc.IntegrationTests/Utils/UriUtils.cs
+++ b/tests/Auth0.AspNetCore.Mvc.IntegrationTests/Utils/UriUtils.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Auth0.AspNetCore.Mvc.IntegrationTests
+namespace Auth0.AspNetCore.Mvc.IntegrationTests.Utils
 {
     /// <summary>
     /// Utils class for Uri's


### PR DESCRIPTION
Doing a few small cleanups (e.g. unused using, fix a few XML comments) as well as adding the following changes to align with https://docs.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/coding-conventions:

- use `_` prefix for private fields
- Do not use `this` in constructor assignments