### PR TITLE
Add Nullable reference types coverage

### DIFF
--- a/src/Auth0.AspNetCore.Mvc/AccessTokenResponse.cs
+++ b/src/Auth0.AspNetCore.Mvc/AccessTokenResponse.cs
@@ -11,7 +11,7 @@ namespace Auth0.AspNetCore.Mvc
         /// Identifier token.
         /// </summary>
         [JsonPropertyName("id_token")]
-        public string IdToken { get; set; }
+        public string IdToken { get; set; } = null!;
 
         /// <summary>
         /// Expiration time in seconds.
@@ -23,12 +23,12 @@ namespace Auth0.AspNetCore.Mvc
         /// Refresh token.
         /// </summary>
         [JsonPropertyName("refresh_token")]
-        public string RefreshToken { get; set; }
+        public string RefreshToken { get; set; } = null!;
 
         /// <summary>
         /// Access token.
         /// </summary>
         [JsonPropertyName("access_token")]
-        public string AccessToken { get; set; }
+        public string AccessToken { get; set; } = null!;
     }
 }

--- a/src/Auth0.AspNetCore.Mvc/Auth0.AspNetCore.Mvc.csproj
+++ b/src/Auth0.AspNetCore.Mvc/Auth0.AspNetCore.Mvc.csproj
@@ -32,6 +32,7 @@
     </PackageReleaseNotes>
     <CLSCompliant>true</CLSCompliant>
     <ComVisible>false</ComVisible>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
     <Major>1</Major>

--- a/src/Auth0.AspNetCore.Mvc/Auth0WebAppOptions.cs
+++ b/src/Auth0.AspNetCore.Mvc/Auth0WebAppOptions.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 
 namespace Auth0.AspNetCore.Mvc
@@ -13,12 +14,12 @@ namespace Auth0.AspNetCore.Mvc
         /// <summary>
         /// Auth0 domain name, e.g. tenant.auth0.com.
         /// </summary>
-        public string Domain { get; set; }
+        public string Domain { get; set; } = null!;
 
         /// <summary>
         /// Client ID of the application.
         /// </summary>
-        public string ClientId { get; set; }
+        public string ClientId { get; set; } = null!;
 
         /// <summary>
         /// Client Secret of the application.
@@ -26,7 +27,7 @@ namespace Auth0.AspNetCore.Mvc
         /// <remarks>
         /// Required when using <see cref="ResponseType"/> set to `code` or `code id_token`.
         /// </remarks>
-        public string ClientSecret { get; set; }
+        public string? ClientSecret { get; set; }
 
         /// <summary>
         /// Scopes to be used to request token(s). (e.g. "Scope1 Scope2 Scope3")
@@ -37,12 +38,12 @@ namespace Auth0.AspNetCore.Mvc
         /// The path within the application to redirect the user to.
         /// </summary>
         /// <remarks>Processed internally by the Open Id Connect middleware.</remarks> 
-        public string CallbackPath { get; set; }
+        public string? CallbackPath { get; set; }
 
         /// <summary>
         /// The Id of the organization to which the users should log in to.
         /// </summary>
-        public string Organization { get; set; }
+        public string? Organization { get; set; }
 
         /// <summary>
         /// Parameters to be send to Auth0's `/authorize` endpoint.
@@ -53,12 +54,12 @@ namespace Auth0.AspNetCore.Mvc
         ///     options.LoginParameters = new Dictionary{string, string}() { {"Test", "123" } };
         /// });
         /// </example>
-        public IDictionary<string, string> LoginParameters { get; set; } = new Dictionary<string, string>();
+        public IDictionary<string, string>? LoginParameters { get; set; } = new Dictionary<string, string>();
 
         /// <summary>
         /// Events allowing you to hook into specific moments in the OpenID Connect pipeline.
         /// </summary>
-        public OpenIdConnectEvents OpenIdConnectEvents { get; set; }
+        public OpenIdConnectEvents? OpenIdConnectEvents { get; set; }
 
         /// <summary>
         /// Set the ResponseType to be used.
@@ -66,12 +67,12 @@ namespace Auth0.AspNetCore.Mvc
         /// <remarks>
         /// Supports `id_token`, `code` or `code id_token`, defaults to `id_token` when omitted.
         /// </remarks>
-        public string ResponseType { get; set; }
+        public string? ResponseType { get; set; }
 
         /// <summary>
         /// Backchannel used to communicate with the Identity Provider.
         /// </summary>
-        public HttpClient Backchannel { get; set; }
+        public HttpClient Backchannel { get; set; } = default!;
 
         /// <summary>
         /// If provided, will set the 'max_age' parameter with the authentication request.

--- a/src/Auth0.AspNetCore.Mvc/Auth0WebAppOptions.cs
+++ b/src/Auth0.AspNetCore.Mvc/Auth0WebAppOptions.cs
@@ -71,7 +71,7 @@ namespace Auth0.AspNetCore.Mvc
         /// <summary>
         /// Backchannel used to communicate with the Identity Provider.
         /// </summary>
-        public HttpClient Backchannel { get; set; } = default!;
+        public HttpClient? Backchannel { get; set; }
 
         /// <summary>
         /// If provided, will set the 'max_age' parameter with the authentication request.

--- a/src/Auth0.AspNetCore.Mvc/Auth0WebAppOptions.cs
+++ b/src/Auth0.AspNetCore.Mvc/Auth0WebAppOptions.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 
 namespace Auth0.AspNetCore.Mvc

--- a/src/Auth0.AspNetCore.Mvc/Auth0WebAppWithAccessTokenAuthenticationBuilder.cs
+++ b/src/Auth0.AspNetCore.Mvc/Auth0WebAppWithAccessTokenAuthenticationBuilder.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Extensions.DependencyInjection;
@@ -49,7 +49,7 @@ namespace Auth0.AspNetCore.Mvc
 
             _services.AddSingleton(auth0WithAccessTokensOptions);
             _services.AddOptions<OpenIdConnectOptions>(Auth0Constants.AuthenticationScheme)
-                .Configure<IServiceProvider>((options, serviceProvider) =>
+                .Configure(options =>
                 {
                     options.ResponseType = OpenIdConnectResponseType.Code;
 
@@ -67,7 +67,7 @@ namespace Auth0.AspNetCore.Mvc
                 });
 
             _services.AddOptions<CookieAuthenticationOptions>(CookieAuthenticationDefaults.AuthenticationScheme)
-                .Configure<IServiceProvider>((options, serviceProvider) =>
+                .Configure(options =>
                 {
                     options.Events.OnValidatePrincipal = Utils.ProxyEvent(CreateOnValidatePrincipal(auth0WithAccessTokensOptions), options.Events.OnValidatePrincipal);
                 });
@@ -104,7 +104,7 @@ namespace Auth0.AspNetCore.Mvc
                         if (context.Properties.Items.TryGetValue(".Token.refresh_token", out var refreshToken))
                         {
                             var now = DateTimeOffset.Now;
-                            var expiresAt = DateTimeOffset.Parse(context.Properties.Items[".Token.expires_at"]);
+                            var expiresAt = DateTimeOffset.Parse(context.Properties.Items[".Token.expires_at"]!);
                             var leeway = 60;
                             var difference = DateTimeOffset.Compare(expiresAt, now.AddSeconds(leeway));
                             var isExpired = difference <= 0;
@@ -122,7 +122,7 @@ namespace Auth0.AspNetCore.Mvc
                                 }
                                 else
                                 {
-                                    context.Properties.UpdateTokenValue("refresh_token", null);
+                                    context.Properties.UpdateTokenValue("refresh_token", null!);
                                 }
 
                                 context.ShouldRenew = true;
@@ -131,7 +131,7 @@ namespace Auth0.AspNetCore.Mvc
                         }
                         else
                         {
-                            if (auth0Options.Events != null && auth0Options.Events.OnMissingRefreshToken != null)
+                            if (auth0Options.Events?.OnMissingRefreshToken != null)
                             {
                                 await auth0Options.Events.OnMissingRefreshToken(context.HttpContext);
                             }
@@ -140,7 +140,7 @@ namespace Auth0.AspNetCore.Mvc
                 }
                 else
                 {
-                    if (CodeResponseTypes.Contains(options.ResponseType))
+                    if (CodeResponseTypes.Contains(options.ResponseType!))
                     {
                         if (auth0Options.Events?.OnMissingAccessToken != null)
                         {
@@ -151,7 +151,7 @@ namespace Auth0.AspNetCore.Mvc
             };
         }
 
-        private static async Task<AccessTokenResponse> RefreshTokens(Auth0WebAppOptions options, string refreshToken, HttpClient httpClient = null)
+        private static async Task<AccessTokenResponse?> RefreshTokens(Auth0WebAppOptions options, string refreshToken, HttpClient? httpClient = null)
         {
             using (var tokenClient = new TokenClient(httpClient))
             {

--- a/src/Auth0.AspNetCore.Mvc/Auth0WebAppWithAccessTokenEvents.cs
+++ b/src/Auth0.AspNetCore.Mvc/Auth0WebAppWithAccessTokenEvents.cs
@@ -30,7 +30,7 @@ namespace Auth0.AspNetCore.Mvc
         ///   });
         /// </code>
         /// </example>
-        public Func<HttpContext, Task> OnMissingAccessToken { get; set; }
+        public Func<HttpContext, Task>? OnMissingAccessToken { get; set; }
 
         /// <summary>
         /// Executed when a Refresh Token is missing where one was expected, allowing you to react accordingly.
@@ -53,6 +53,6 @@ namespace Auth0.AspNetCore.Mvc
         ///   });
         /// </code>
         /// </example>
-        public Func<HttpContext, Task> OnMissingRefreshToken { get; set; }
+        public Func<HttpContext, Task>? OnMissingRefreshToken { get; set; }
     }
 }

--- a/src/Auth0.AspNetCore.Mvc/Auth0WebAppWithAccessTokenOptions.cs
+++ b/src/Auth0.AspNetCore.Mvc/Auth0WebAppWithAccessTokenOptions.cs
@@ -8,12 +8,12 @@
         /// <summary>
         /// The audience to be used for requesting API access.
         /// </summary>
-        public string Audience { get; set; }
+        public string? Audience { get; set; }
 
         /// <summary>
         /// Scopes to be used to request token(s). (e.g. "Scope1 Scope2 Scope3")
         /// </summary>
-        public string Scope { get; set; }
+        public string? Scope { get; set; }
 
         /// <summary>
         /// Define whether or not Refresh Tokens should be used internally when the access token is expired.
@@ -23,6 +23,6 @@
         /// <summary>
         /// Events allowing you to hook into specific moments in the Auth0 middleware.
         /// </summary>
-        public Auth0WebAppWithAccessTokenEvents Events { get; set; }
+        public Auth0WebAppWithAccessTokenEvents? Events { get; set; }
     }
 }

--- a/src/Auth0.AspNetCore.Mvc/AuthenticationBuilderExtensions.cs
+++ b/src/Auth0.AspNetCore.Mvc/AuthenticationBuilderExtensions.cs
@@ -83,7 +83,7 @@ namespace Auth0.AspNetCore.Mvc
 
         private static void ValidateOptions(Auth0WebAppOptions auth0Options)
         {
-            if (CodeResponseTypes.Contains(auth0Options.ResponseType) && string.IsNullOrWhiteSpace(auth0Options.ClientSecret))
+            if (CodeResponseTypes.Contains(auth0Options.ResponseType!) && string.IsNullOrWhiteSpace(auth0Options.ClientSecret))
             {
                 throw new ArgumentNullException(nameof(auth0Options.ClientSecret), "Client Secret can not be null when using `code` or `code id_token` as the response_type.");
             }

--- a/src/Auth0.AspNetCore.Mvc/AuthenticationBuilderExtensions.cs
+++ b/src/Auth0.AspNetCore.Mvc/AuthenticationBuilderExtensions.cs
@@ -59,7 +59,7 @@ namespace Auth0.AspNetCore.Mvc
             oidcOptions.CallbackPath = new PathString(auth0Options.CallbackPath ?? Auth0Constants.DefaultCallbackPath);
             oidcOptions.SaveTokens = true;
             oidcOptions.ResponseType = auth0Options.ResponseType ?? oidcOptions.ResponseType;
-            oidcOptions.Backchannel = auth0Options.Backchannel;
+            oidcOptions.Backchannel = auth0Options.Backchannel!;
             oidcOptions.MaxAge = auth0Options.MaxAge;
 
             if (!oidcOptions.Scope.Contains("openid"))

--- a/src/Auth0.AspNetCore.Mvc/BaseAuthenticationPropertiesBuilder.cs
+++ b/src/Auth0.AspNetCore.Mvc/BaseAuthenticationPropertiesBuilder.cs
@@ -6,10 +6,10 @@ namespace Auth0.AspNetCore.Mvc
     {
         protected readonly AuthenticationProperties AuthenticationProperties;
 
-        protected BaseAuthenticationPropertiesBuilder(AuthenticationProperties properties = null)
+        protected BaseAuthenticationPropertiesBuilder(AuthenticationProperties? properties = null)
         {
             AuthenticationProperties = properties ?? new AuthenticationProperties();
-            AuthenticationProperties.RedirectUri = AuthenticationProperties.RedirectUri ?? "/";
+            AuthenticationProperties.RedirectUri ??= "/";
         }
     }
 }

--- a/src/Auth0.AspNetCore.Mvc/IdTokenValidator.cs
+++ b/src/Auth0.AspNetCore.Mvc/IdTokenValidator.cs
@@ -11,7 +11,7 @@ namespace Auth0.AspNetCore.Mvc
 {
     internal static class IdTokenValidator
     {
-        public static void Validate(Auth0WebAppOptions auth0Options, JwtSecurityToken token, IDictionary<string, string> properties = null)
+        public static void Validate(Auth0WebAppOptions auth0Options, JwtSecurityToken token, IDictionary<string, string?>? properties = null)
         {
             var organization = properties != null && properties.ContainsKey(Auth0AuthenticationParameters.Organization) ? properties[Auth0AuthenticationParameters.Organization] : null;
 

--- a/src/Auth0.AspNetCore.Mvc/LoginAuthenticationPropertiesBuilder.cs
+++ b/src/Auth0.AspNetCore.Mvc/LoginAuthenticationPropertiesBuilder.cs
@@ -11,7 +11,7 @@ namespace Auth0.AspNetCore.Mvc
     public class LoginAuthenticationPropertiesBuilder: BaseAuthenticationPropertiesBuilder
     {
 
-        public LoginAuthenticationPropertiesBuilder(AuthenticationProperties properties = null): base(properties)
+        public LoginAuthenticationPropertiesBuilder(AuthenticationProperties? properties = null): base(properties)
         {
         }
 

--- a/src/Auth0.AspNetCore.Mvc/LogoutAuthenticationPropertiesBuilder.cs
+++ b/src/Auth0.AspNetCore.Mvc/LogoutAuthenticationPropertiesBuilder.cs
@@ -12,7 +12,7 @@ namespace Auth0.AspNetCore.Mvc
     public class LogoutAuthenticationPropertiesBuilder: BaseAuthenticationPropertiesBuilder
     {
 
-        public LogoutAuthenticationPropertiesBuilder(AuthenticationProperties properties = null): base(properties)
+        public LogoutAuthenticationPropertiesBuilder(AuthenticationProperties? properties = null): base(properties)
         {
                 
         }
@@ -34,7 +34,7 @@ namespace Auth0.AspNetCore.Mvc
         /// <param name="key">The key for the parameter.</param>
         /// <param name="value">The value for the parameter.</param>
         /// <returns>The current <see cref="LogoutAuthenticationPropertiesBuilder"/> instance.</returns>
-        public LogoutAuthenticationPropertiesBuilder WithParameter(string key, string value = null)
+        public LogoutAuthenticationPropertiesBuilder WithParameter(string key, string? value = null)
         {
             AuthenticationProperties.Items.Add(Auth0AuthenticationParameters.Parameter(key), value);
             return this;

--- a/src/Auth0.AspNetCore.Mvc/OpenIdConnectEventsFactory.cs
+++ b/src/Auth0.AspNetCore.Mvc/OpenIdConnectEventsFactory.cs
@@ -29,7 +29,7 @@ namespace Auth0.AspNetCore.Mvc
             };
         }
 
-        private static Func<T, Task> ProxyEvent<T>(Func<T, Task> originalHandler, Func<T, Task> newHandler = null)
+        private static Func<T, Task> ProxyEvent<T>(Func<T, Task>? originalHandler, Func<T, Task>? newHandler = null)
         {
             return async (context) =>
             {
@@ -86,15 +86,15 @@ namespace Auth0.AspNetCore.Mvc
                     logoutUri += $"&returnTo={ Uri.EscapeDataString(postLogoutUri)}";
                 }
 
-                foreach (var parameter in parameters)
+                foreach (var (key, value) in parameters)
                 {
-                    if (!string.IsNullOrEmpty(parameter.Value))
+                    if (!string.IsNullOrEmpty(value))
                     {
-                        logoutUri += $"&{parameter.Key}={ Uri.EscapeDataString(parameter.Value)}";
+                        logoutUri += $"&{key}={ Uri.EscapeDataString(value)}";
                     }
                     else
                     {
-                        logoutUri += $"&{parameter.Key}";
+                        logoutUri += $"&{key}";
                     }
                 }
 
@@ -122,9 +122,9 @@ namespace Auth0.AspNetCore.Mvc
             };
         }
 
-        private static IDictionary<string, string> GetAuthorizeParameters(Auth0WebAppOptions auth0Options, IDictionary<string, string> authSessionItems)
+        private static IDictionary<string, string?> GetAuthorizeParameters(Auth0WebAppOptions auth0Options, IDictionary<string, string?> authSessionItems)
         {
-            var parameters = new Dictionary<string, string>();
+            var parameters = new Dictionary<string, string?>();
 
             if (!string.IsNullOrEmpty(auth0Options.Organization))
             {
@@ -144,10 +144,10 @@ namespace Auth0.AspNetCore.Mvc
             foreach (var item in GetExtraParameters(authSessionItems))
             {
                 var value = item.Value;
-                if (item.Key == "scope")
+                if (item.Key == "scope" && value != null)
                 {
                     // Openid is a required scope, meaning that when omitted we need to ensure it gets added.
-                    if (value.IndexOf("openid", StringComparison.CurrentCultureIgnoreCase) == -1)
+                    if (!value.Contains("openid", StringComparison.CurrentCultureIgnoreCase))
                     {
                         value += " openid";
                     }
@@ -159,13 +159,13 @@ namespace Auth0.AspNetCore.Mvc
             return parameters;
         }
 
-        private static IDictionary<string, string> GetExtraParameters(IDictionary<string, string> authSessionItems)
+        private static IDictionary<string, string?> GetExtraParameters(IDictionary<string, string?> authSessionItems)
         {
-            var parameters = new Dictionary<string, string>();
+            var parameters = new Dictionary<string, string?>();
 
-            foreach (var item in authSessionItems.Where(item => item.Key.StartsWith($"{Auth0AuthenticationParameters.Prefix}:")))
+            foreach (var (key, value) in authSessionItems.Where(item => item.Key.StartsWith($"{Auth0AuthenticationParameters.Prefix}:")))
             {
-                parameters[item.Key.Replace($"{Auth0AuthenticationParameters.Prefix}:", "")] = item.Value;
+                parameters[key.Replace($"{Auth0AuthenticationParameters.Prefix}:", "")] = value;
             }
 
             return parameters;

--- a/src/Auth0.AspNetCore.Mvc/OpenIdConnectEventsFactory.cs
+++ b/src/Auth0.AspNetCore.Mvc/OpenIdConnectEventsFactory.cs
@@ -144,10 +144,14 @@ namespace Auth0.AspNetCore.Mvc
             foreach (var item in GetExtraParameters(authSessionItems))
             {
                 var value = item.Value;
-                if (item.Key == "scope" && value != null)
+                if (item.Key == "scope")
                 {
                     // Openid is a required scope, meaning that when omitted we need to ensure it gets added.
-                    if (!value.Contains("openid", StringComparison.CurrentCultureIgnoreCase))
+                    if (value == null)
+                    {
+                        value = "openid";
+                    }
+                    else if (!value.Contains("openid", StringComparison.CurrentCultureIgnoreCase))
                     {
                         value += " openid";
                     }

--- a/src/Auth0.AspNetCore.Mvc/TokenClient.cs
+++ b/src/Auth0.AspNetCore.Mvc/TokenClient.cs
@@ -16,7 +16,7 @@ namespace Auth0.AspNetCore.Mvc
             IgnoreNullValues = true,
         };
 
-        public TokenClient(HttpClient httpClient = null)
+        public TokenClient(HttpClient? httpClient = null)
         {
             _isHttpClientOwner = httpClient == null;
             _httpClient = httpClient ?? new HttpClient();
@@ -30,16 +30,16 @@ namespace Auth0.AspNetCore.Mvc
             }
         }
 
-        public async Task<AccessTokenResponse> Refresh(Auth0WebAppOptions options, string refreshToken)
+        public async Task<AccessTokenResponse?> Refresh(Auth0WebAppOptions options, string refreshToken)
         {
             var body = new Dictionary<string, string> {
                 { "grant_type", "refresh_token" },
                 { "client_id", options.ClientId },
-                { "client_secret", options.ClientSecret },
+                { "client_secret", options.ClientSecret! },
                 { "refresh_token", refreshToken }
             };
 
-            var requestContent = new FormUrlEncodedContent(body.Select(p => new KeyValuePair<string, string>(p.Key, p.Value ?? "")));
+            var requestContent = new FormUrlEncodedContent(body.Select(p => new KeyValuePair<string?, string?>(p.Key, p.Value ?? "")));
 
             using (var request = new HttpRequestMessage(HttpMethod.Post, $"https://{options.Domain}/oauth/token") { Content = requestContent })
             {


### PR DESCRIPTION
### Description

Adds [C#8+ nullability coverage](https://docs.microsoft.com/en-us/dotnet/csharp/nullable-references).

I generally follow the [runtime nullability guidance](https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/api-guidelines/nullability.md) as it's far more detailed than Microsoft's documentation.

### References

Closes #42 

### Testing

Nullability annotations are a compile-time assistant and thus have no runtime effects. All tests are passing.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`
